### PR TITLE
Rollback crate root finder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,6 @@ repository = "https://github.com/ANLAB-KAIST/rust-static-config"
 [build-dependencies]
 num_cpus = "1"
 toml = "0.5"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
 etrace = "1"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "static-config"
 version = "0.0.1"
-authors = ["Keunhong Lee <dlrmsghd@gmail.com>", "ANLAB <support@an.kaist.ac.kr>"]
+authors = ["Keunhong Lee <dlrmsghd@gmail.com>", "Jeehoon Kang <jeehoon.kang@kaist.ac.kr>", "ANLAB <support@an.kaist.ac.kr>"]
 edition = "2018"
 license = "MIT"
 publish = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ repository = "https://github.com/ANLAB-KAIST/rust-static-config"
 num_cpus = "1"
 toml = "0.5"
 etrace = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [dev-dependencies]
 num_cpus = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,6 @@ repository = "https://github.com/ANLAB-KAIST/rust-static-config"
 [build-dependencies]
 num_cpus = "1"
 toml = "0.5"
-etrace = "1"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
 
 [dev-dependencies]
 num_cpus = "1"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,6 +28,15 @@ pipeline {
             steps {
                 sh 'cargo test -- --nocapture --test-threads=1'
                 sh 'cargo test --release -- --nocapture --test-threads=1'
+                dir("test_workspace") {
+                    sh "pwd"
+                    sh 'cargo fmt --all -- --check'
+                    sh 'cargo clippy -- -D warnings'
+                    sh 'cargo build'
+                    sh 'cargo build --release'
+                    sh 'cargo test -- --nocapture --test-threads=1'
+                    sh 'cargo test --release -- --nocapture --test-threads=1'
+                }
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -5,10 +5,20 @@
 ## What is this?
 
 If configuration values are obtained from `env` or `toml`, Rust compiler considers those values as dynamic values.
-Thus, we cannot use the values to configure a fixed-length array's length.
+Thus, Rust compiler cannot optimized them as constant values.
+Furthermore, a fixed-length array only accepts integers with const types.
+A constant with non-const type (e.g. `let val = 3;`) cannot be used.
 
 `static-config` reads the content of `static_config.toml` at the crate root and embedded the values as a static rust source file.
 Values from `static_config.toml` can be accessed as pre-defined constants.
+
+## How to use
+
+1. Add this library to your dependency list.
+1. Put `static_config.toml` to the root of your crate/workspace (where you type `cargo` commands).
+1. (Warning) This library will not work if the target directory is changed via env vars or cargo options.
+1. Values from the TOML file is obtained through `static_config::config` API.
+1. To use integer values as length of a fixed-length array, all integer values within the system's `usize` range are also defined in `static_config::CONST_USIZE`.
 
 ## Example of `static_config.toml`
 
@@ -35,15 +45,15 @@ u64 = 9223372036854775807 # Max int type is i64
 The following command is fully optimized-out into a const value.
 
 ```{.rs}
-assert!(true == r::static_config::config("level1.bool").try_into().unwrap());
+assert!(true == static_config::config("level1.bool").try_into().unwrap());
 ```
 
 If you want a `const usize` type to be used in array length:
 
 ```{.rs}
-assert!(255usize == r::static_config::CONST_USIZE.LEVEL1_LEVEL2_U8);
+assert!(255usize == static_config::CONST_USIZE.LEVEL1_LEVEL2_U8);
 ```
 
 ## `static_config::CPU_COUNT`
 
-`static_config` provides a `CPU_COUNT` constant which is measured at `cargo build`.
+`static_config` provides a `CPU_COUNT` constant measured by `num_cpus` crate.

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,4 @@
 use etrace::some_or;
-use serde::Deserialize;
-use serde_json;
 use std::collections::LinkedList;
 use std::convert::TryFrom;
 use std::env;
@@ -22,27 +20,30 @@ fn cpu_count(out_path: &PathBuf) {
 /// Root crate dir is not given as cargo env.
 /// (https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates)
 ///
-/// Related issue: https://github.com/rust-lang/cargo/issues/3946
-/// This function is modified from https://github.com/mitsuhiko/insta/blob/b113499249584cb650150d2d01ed96ee66db6b30/src/runtime.rs#L67-L88
+/// Related issue: https://github.com/rust-lang/cargo/issues/3946 This function is modified from
+/// https://github.com/mitsuhiko/insta/blob/b113499249584cb650150d2d01ed96ee66db6b30/src/runtime.rs#L67-L88
+///
+/// However, this cannot capture the root directory when this library is called as an external
+/// library.
+///
+/// Even when a crate is built as an external library, it shares the same `target` directory as its
+/// parent crate.  Thus, we try to find the root directory by tracking parent directories from
+/// `OUT_DIR` which contains `target` directory as its child.
 fn get_cargo_workspace() -> PathBuf {
-    let cargo_bin = std::env::var("CARGO").unwrap_or("cargo".to_string());
-    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
-        .map(PathBuf::from)
-        .unwrap();
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let mut out_dir = Path::new(&out_dir);
+    assert!(out_dir.is_dir());
+    loop {
+        let is_end = out_dir.file_name().unwrap() == "target";
 
-    #[derive(Deserialize)]
-    struct Manifest {
-        workspace_root: String,
+        out_dir = Path::new(out_dir.parent().unwrap());
+
+        if is_end {
+            break;
+        }
     }
-    let output = std::process::Command::new(cargo_bin)
-        .arg("metadata")
-        .arg("--format-version=1")
-        .current_dir(manifest_dir)
-        .output()
-        .unwrap();
 
-    let manifest: Manifest = serde_json::from_slice(&output.stdout).unwrap();
-    return PathBuf::from(manifest.workspace_root);
+    return out_dir.to_path_buf();
 }
 
 /// Read `static_config.toml` and generate embedded source file.

--- a/test_workspace/Cargo.toml
+++ b/test_workspace/Cargo.toml
@@ -1,0 +1,5 @@
+[workspace]
+
+members = [
+  "test_lib_link"
+]

--- a/test_workspace/static_config.toml
+++ b/test_workspace/static_config.toml
@@ -1,0 +1,2 @@
+[new]
+string = "1ce50a37"

--- a/test_workspace/test_lib_link/Cargo.toml
+++ b/test_workspace/test_lib_link/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "test_lib_link"
+version = "0.0.1"
+authors = ["Keunhong Lee <dlrmsghd@gmail.com>", "ANLAB <support@an.kaist.ac.kr>"]
+edition = "2018"
+license = "MIT"
+publish = false
+description = """
+Test whether `static-config` works.
+"""
+
+[dependencies]
+static-config = { path = "../../" }
+
+[lib]
+name = "test_lib_link"
+
+[features]

--- a/test_workspace/test_lib_link/src/lib.rs
+++ b/test_workspace/test_lib_link/src/lib.rs
@@ -1,6 +1,6 @@
-use static_config;
 use std::convert::TryInto;
 
+/// Return desired value from static config
 pub fn get_new_val() -> &'static str {
-    return static_config::config("new.string").try_into().unwrap()
+    static_config::config("new.string").try_into().unwrap()
 }

--- a/test_workspace/test_lib_link/src/lib.rs
+++ b/test_workspace/test_lib_link/src/lib.rs
@@ -1,0 +1,6 @@
+use static_config;
+use std::convert::TryInto;
+
+pub fn get_new_val() -> &'static str {
+    return static_config::config("new.string").try_into().unwrap()
+}

--- a/test_workspace/test_lib_link/tests/test_new_val.rs
+++ b/test_workspace/test_lib_link/tests/test_new_val.rs
@@ -2,7 +2,5 @@ use test_lib_link::get_new_val;
 
 #[test]
 fn test_new_val() {
-    assert!(
-        "1ce50a37".eq(get_new_val())
-    );
+    assert!("1ce50a37".eq(get_new_val()));
 }

--- a/test_workspace/test_lib_link/tests/test_new_val.rs
+++ b/test_workspace/test_lib_link/tests/test_new_val.rs
@@ -1,0 +1,8 @@
+use test_lib_link::get_new_val;
+
+#[test]
+fn test_new_val() {
+    assert!(
+        "1ce50a37".eq(get_new_val())
+    );
+}


### PR DESCRIPTION
기존 방법은 현재 프로젝트 (static_config를 직접 사용 혹은 workspace member 로 사용) 하는 경우에 잘 작동합니다.
하지만 다른 crate가 이 프로젝트를 external library 로 사용하는 경우에는 그 "다른 crate" 안에 정의된 toml 파일을 찾지 못하고 library linking 을 위해서 복사된 이 static_config 프로젝트의 toml 파일을 찾게 됩니다.

빌드 과정은 다음과 같습니다.

1. 어떠한 crate/workspace 를 빌드 시작
1. 의존성 있는 crate들을 임시 폴더에 복사
1. 각 의존성 crate들을 개별적으로 빌드해서 lib 파일을 생성
1. 위 과정에서 개별 crate들은 자기 자신이 project root 라고 인식 (최초에 호출한 workspace 포함 안됨)
1. 하여 이 `rust-static-config` 프로젝트의 테스트를 위해서 들어있는 `static_config.toml` 파일을 참조하게 됨.

이 PR은 이걸 휴리스틱으로 해결합니다.
1. 모든 의존성 crate를 포함한 임시 파일은 `target/xxxx/...` 안에 생성됩니다.
1. 이 안에는 각 crate의 임시 파일을 합법적으로 (cargo에서) 만들 수 있는 `OUT_DIR`이 제공됩니다.
1. 위에서 언급한 `target` 디렉토리는 최초에 cargo를 호출한 폴더 안에 생깁니다.
1. `OUT_DIR`로 부터 `target` 디렉토리 바깥으로 나가는 순간이 최초의 project root라 추정할 수 있습니다.

또한 실제 링크가 확실히 잘 되는 것 까지를 테스트하는 코드를 추가했습니다.